### PR TITLE
Memory model

### DIFF
--- a/src/Ganeti/HTools/Backend/Luxi.hs
+++ b/src/Ganeti/HTools/Backend/Luxi.hs
@@ -136,7 +136,7 @@ queryInstancesMsg :: L.LuxiOp
 queryInstancesMsg =
   L.Query (Qlang.ItemTypeOpCode Qlang.QRInstance)
      ["name", "disk_usage", "be/memory", "be/vcpus",
-      "status", "pnode", "snodes", "tags", "oper_ram",
+      "status", "pnode", "snodes", "tags",
       "be/auto_balance", "disk_template",
       "be/spindle_use", "disk.sizes", "disk.spindles",
       "forthcoming"] Qlang.EmptyFilter
@@ -179,15 +179,13 @@ parseInstance :: NameAssoc
               -> [(JSValue, JSValue)]
               -> Result (String, Instance.Instance)
 parseInstance ktn [ name, disk, mem, vcpus
-                  , status, pnode, snodes, tags, oram
+                  , status, pnode, snodes, tags,
                   , auto_balance, disk_template, su
                   , dsizes, dspindles, forthcoming ] = do
   xname <- annotateResult "Parsing new instance" (fromJValWithStatus name)
   let convert a = genericConvert "Instance" xname a
   xdisk <- convert "disk_usage" disk
-  xmem <- case oram of -- FIXME: remove the "guessing"
-            (_, JSRational _ _) -> convert "oper_ram" oram
-            _ -> convert "be/memory" mem
+  xmem <- convert "be/memory" mem
   xvcpus <- convert "be/vcpus" vcpus
   xpnode <- convert "pnode" pnode >>= lookupNode ktn xname
   xsnodes <- convert "snodes" snodes::Result [String]

--- a/src/Ganeti/HTools/Backend/Luxi.hs
+++ b/src/Ganeti/HTools/Backend/Luxi.hs
@@ -46,8 +46,10 @@ import Ganeti.BasicTypes
 import Ganeti.Errors
 import qualified Ganeti.Luxi as L
 import qualified Ganeti.Query.Language as Qlang
+import Ganeti.Types (Hypervisor(..))
 import Ganeti.HTools.Loader
 import Ganeti.HTools.Types
+import qualified Ganeti.HTools.Container as Container
 import qualified Ganeti.HTools.Group as Group
 import qualified Ganeti.HTools.Node as Node
 import qualified Ganeti.HTools.Instance as Instance
@@ -179,7 +181,7 @@ parseInstance :: NameAssoc
               -> [(JSValue, JSValue)]
               -> Result (String, Instance.Instance)
 parseInstance ktn [ name, disk, mem, vcpus
-                  , status, pnode, snodes, tags,
+                  , status, pnode, snodes, tags
                   , auto_balance, disk_template, su
                   , dsizes, dspindles, forthcoming ] = do
   xname <- annotateResult "Parsing new instance" (fromJValWithStatus name)
@@ -257,14 +259,15 @@ parseNode ktg [ name, mtotal, mnode, mfree, dtotal, dfree
 parseNode _ v = fail ("Invalid node query result: " ++ show v)
 
 -- | Parses the cluster tags.
-getClusterData :: JSValue -> Result ([String], IPolicy, String)
+getClusterData :: JSValue -> Result ([String], IPolicy, String, Hypervisor)
 getClusterData (JSObject obj) = do
   let errmsg = "Parsing cluster info"
       obj' = fromJSObject obj
   ctags <- tryFromObj errmsg obj' "tags"
   cpol <- tryFromObj errmsg obj' "ipolicy"
   master <- tryFromObj errmsg obj' "master"
-  return (ctags, cpol, master)
+  hypervisor <- tryFromObj errmsg obj' "default_hypervisor"
+  return (ctags, cpol, master, hypervisor)
 
 getClusterData _ = Bad "Cannot parse cluster info, not a JSON record"
 
@@ -314,9 +317,10 @@ parseData (groups, nodes, instances, cinfo) = do
   let (node_names, node_idx) = assignIndices node_data
   inst_data <- instances >>= getInstances node_names
   let (_, inst_idx) = assignIndices inst_data
-  (ctags, cpol, master) <- cinfo >>= getClusterData
+  (ctags, cpol, master, hypervisor) <- cinfo >>= getClusterData
   node_idx' <- setMaster node_names node_idx master
-  return (ClusterData group_idx node_idx' inst_idx ctags cpol)
+  let node_idx'' = Container.map (`Node.setHypervisor` hypervisor) node_idx'
+  return (ClusterData group_idx node_idx'' inst_idx ctags cpol)
 
 -- | Top level function for data loading.
 loadData :: String -- ^ Unix socket to use as source

--- a/src/Ganeti/HTools/CLI.hs
+++ b/src/Ganeti/HTools/CLI.hs
@@ -112,6 +112,7 @@ module Ganeti.HTools.CLI
   , oShowVer
   , oShowComp
   , oSkipNonRedundant
+  , oStaticKvmNodeMemory
   , oStdSpec
   , oTargetResources
   , oTieredSpec
@@ -203,6 +204,7 @@ data Options = Options
   , optShowNodes   :: Maybe [String] -- ^ Whether to show node status
   , optShowVer     :: Bool           -- ^ Just show the program version
   , optSkipNonRedundant :: Bool      -- ^ Skip nodes with non-redundant instance
+  , optStaticKvmNodeMemory :: Int    -- ^ Use static value for node memory on KVM
   , optStdSpec     :: Maybe RSpec    -- ^ Requested standard specs
   , optTargetResources :: Double     -- ^ Target resources for squeezing
   , optTestCount   :: Maybe Int      -- ^ Optional test count override
@@ -259,6 +261,7 @@ defaultOptions  = Options
   , optNodeSim     = []
   , optNodeTags    = Nothing
   , optSkipNonRedundant = False
+  , optStaticKvmNodeMemory = 4096
   , optOffline     = []
   , optRestrictToNodes = Nothing
   , optOfflineMaintenance = False
@@ -659,7 +662,7 @@ oNodeTags =
    (ReqArg (\ f opts -> Ok opts { optNodeTags = Just $ sepSplit ',' f })
     "TAG,...") "Restrict to nodes with the given tags",
    OptComplString)
-     
+
 oOfflineMaintenance :: OptType
 oOfflineMaintenance =
   (Option "" ["offline-maintenance"]
@@ -761,6 +764,14 @@ oSkipNonRedundant =
    (NoArg (\ opts -> Ok opts { optSkipNonRedundant = True }))
     "Skip nodes that host a non-redundant instance",
     OptComplNone)
+
+oStaticKvmNodeMemory :: OptType
+oStaticKvmNodeMemory =
+  (Option "" ["static-kvm-node-memory"]
+   (reqWithConversion (tryRead "static node memory")
+    (\i opts -> Ok opts { optStaticKvmNodeMemory = i }) "N")
+   "use static node memory [in MB] on KVM instead of value reported by hypervisor.",
+   OptComplInteger)
 
 oStdSpec :: OptType
 oStdSpec =

--- a/src/Ganeti/HTools/Cluster.hs
+++ b/src/Ganeti/HTools/Cluster.hs
@@ -226,11 +226,9 @@ updateCStats cs node =
                csFspn = x_fspn, csIspn = x_ispn, csTspn = x_tspn
              }
         = cs
-      inc_amem = Node.fMem node - Node.rMem node
-      inc_amem' = if inc_amem > 0 then inc_amem else 0
+      inc_amem = Node.availMem node
       inc_adsk = Node.availDisk node
-      inc_imem = truncate (Node.tMem node) - Node.nMem node
-                 - Node.xMem node - Node.fMem node
+      inc_imem = Node.iMem node
       inc_icpu = Node.uCpu node
       inc_idsk = truncate (Node.tDsk node) - Node.fDsk node
       inc_ispn = Node.tSpindles node - Node.fSpindles node
@@ -238,13 +236,13 @@ updateCStats cs node =
       inc_acpu = Node.availCpu node
       inc_ncpu = fromIntegral (Node.uCpu node) /
                  iPolicyVcpuRatio (Node.iPolicy node)
-  in cs { csFmem = x_fmem + fromIntegral (Node.fMem node)
+  in cs { csFmem = x_fmem + fromIntegral (Node.guaranteedFreeMem node)
         , csFdsk = x_fdsk + fromIntegral (Node.fDsk node)
         , csFspn = x_fspn + fromIntegral (Node.fSpindles node)
-        , csAmem = x_amem + fromIntegral inc_amem'
+        , csAmem = x_amem + fromIntegral inc_amem
         , csAdsk = x_adsk + fromIntegral inc_adsk
         , csAcpu = x_acpu + fromIntegral inc_acpu
-        , csMmem = max x_mmem (fromIntegral inc_amem')
+        , csMmem = max x_mmem (fromIntegral inc_amem)
         , csMdsk = max x_mdsk (fromIntegral inc_adsk)
         , csMcpu = max x_mcpu (fromIntegral inc_acpu)
         , csImem = x_imem + fromIntegral inc_imem
@@ -778,9 +776,8 @@ iterateAllocSmallStep opts nl il limit newinst allocnodes ixes cstats =
 guessBigstepSize :: Node.List -> Instance.Instance -> Int
 guessBigstepSize nl inst =
   let nodes = Container.elems nl
-      totalUnusedMemory = sum $ map Node.fMem nodes
-      reserved = round . maximum $ map Node.tMem nodes
-      capacity = (totalUnusedMemory - reserved) `div` Instance.mem inst
+      totalAvail = sum $ map Node.availMem nodes
+      capacity = totalAvail `div` Instance.mem inst
       -- however, at every node we might lose almost an instance if it just
       -- doesn't fit by a tiny margin
       guess = capacity - Container.size nl

--- a/src/Ganeti/HTools/ExtLoader.hs
+++ b/src/Ganeti/HTools/ExtLoader.hs
@@ -61,7 +61,7 @@ import qualified Ganeti.HTools.Backend.IAlloc as IAlloc
 import qualified Ganeti.HTools.Backend.MonD as MonD
 import Ganeti.HTools.CLI
 import Ganeti.HTools.Loader (mergeData, checkData, ClusterData(..)
-                            , commonSuffix, clearDynU)
+                            , commonSuffix, clearDynU, setStaticKvmNodeMem)
 import Ganeti.HTools.Types
 import Ganeti.Utils (sepSplit, tryRead, exitIfBad, exitWhen)
 
@@ -122,8 +122,15 @@ loadExternalData opts = do
   now <- getClockTime
 
   let ignoreDynU = optIgnoreDynu opts
+      nodeMem = optStaticKvmNodeMemory opts
       eff_u = if ignoreDynU then [] else util_data
       ldresult = input_data >>= (if ignoreDynU then clearDynU else return)
+                            -- This overrides node mem on KVM as loaded from
+                            -- backend. Ganeti 2.17 handles this for Luxi
+                            -- using obtainNodeMemory.
+                            >>= (if nodeMem >= 0
+                                 then flip setStaticKvmNodeMem nodeMem
+                                 else return)
                             >>= mergeData eff_u exTags selInsts exInsts now
   cdata <- exitIfBad "failed to load data, aborting" ldresult
   (cdata', ok) <- runWriterT $ if optMonD opts

--- a/src/Ganeti/HTools/Node.hs
+++ b/src/Ganeti/HTools/Node.hs
@@ -1,5 +1,4 @@
 {-| Module describing a node.
-
     All updates are functional (copy-based) and return a new node with
     updated value.
 -}
@@ -59,6 +58,7 @@ module Ganeti.HTools.Node
   , setMigrationTags
   , setRecvMigrationTags
   , setLocationTags
+  , setHypervisor
   -- * Tag maps
   , addTags
   , delTags
@@ -113,7 +113,7 @@ import Text.Printf (printf)
 
 import qualified Ganeti.Constants as C
 import qualified Ganeti.OpCodes as OpCodes
-import Ganeti.Types (OobCommand(..), TagKind(..), mkNonEmpty)
+import Ganeti.Types (Hypervisor(..), OobCommand(..), TagKind(..), mkNonEmpty)
 import Ganeti.HTools.Container (Container)
 import qualified Ganeti.HTools.Container as Container
 import Ganeti.HTools.Instance (Instance)
@@ -213,6 +213,7 @@ data Node = Node
   , instanceMap :: Map.Map (String, String) Int -- ^ Number of instances with
                                                 -- each exclusion/location tags
                                                 -- pair
+  , hypervisor :: Maybe Hypervisor -- ^ Active hypervisor on the node
   } deriving (Show, Eq)
 {- A note on how we handle spindles
 
@@ -378,6 +379,7 @@ create name_init mem_t_init mem_n_init mem_f_init
        , locationTags = Set.empty
        , locationScore = 0
        , instanceMap = Map.empty
+       , hypervisor = Nothing
        }
 
 -- | Conversion formula from mDsk\/tDsk to loDsk.
@@ -431,6 +433,10 @@ setLocationTags t val = t { locationTags = val }
 -- | Sets the unnaccounted memory.
 setXmem :: Node -> Int -> Node
 setXmem t val = t { xMem = val }
+
+-- | Sets the hypervisor attribute.
+setHypervisor :: Node -> Hypervisor -> Node
+setHypervisor t val = t { hypervisor = Just val }
 
 -- | Sets the max disk usage ratio.
 setMdsk :: Node -> Double -> Node

--- a/src/Ganeti/HTools/Node.hs
+++ b/src/Ganeti/HTools/Node.hs
@@ -45,7 +45,6 @@ module Ganeti.HTools.Node
   , setIdx
   , setAlias
   , setOffline
-  , setXmem
   , setPri
   , calcFmemOfflineOrForthcoming
   , setSec
@@ -77,8 +76,10 @@ module Ganeti.HTools.Node
   -- * Stats
   , availDisk
   , availMem
+  , missingMem
+  , guaranteedFreeMem
+  , recordedFreeMem
   , availCpu
-  , iMem
   , iDsk
   , conflictingPrimaries
   -- * Generate OpCodes
@@ -132,11 +133,13 @@ type TagMap = Map.Map String Int
 data Node = Node
   { name     :: String    -- ^ The node name
   , alias    :: String    -- ^ The shortened name (for display purposes)
-  , tMem     :: Double    -- ^ Total memory (MiB)
-  , nMem     :: Int       -- ^ Node memory (MiB)
-  , fMem     :: Int       -- ^ Free memory (MiB)
+  , tMem     :: Double    -- ^ Total memory (MiB) (state-of-world)
+  , nMem     :: Int       -- ^ Node memory (MiB) (state-of-record)
+  , iMem     :: Int       -- ^ Instance memory (MiB) (state-of-record)
+  , fMem     :: Int       -- ^ Free memory (MiB) (state-of-world)
   , fMemForth :: Int      -- ^ Free memory (MiB) including forthcoming
-                          --   instances
+                          --   instances TODO: Use state of record calculations
+                          --   for forthcoming instances (see guaranteedFreeMem)
   , xMem     :: Int       -- ^ Unaccounted memory (MiB)
   , tDsk     :: Double    -- ^ Total disk space (MiB)
   , fDsk     :: Int       -- ^ Free disk space (MiB)
@@ -320,6 +323,9 @@ create name_init mem_t_init mem_n_init mem_f_init
        , alias = name_init
        , tMem = mem_t_init
        , nMem = mem_n_init
+       , iMem = 0 -- updated after instances are loaded
+       , xMem = 0 -- updated after instances are loaded
+       , pMem = 0 -- updated after instances are loaded
        , fMem = mem_f_init
        , fMemForth = mem_f_init
        , tDsk = dsk_t_init
@@ -343,7 +349,6 @@ create name_init mem_t_init mem_n_init mem_f_init
        , peers = P.empty
        , rMem = 0
        , rMemForth = 0
-       , pMem = fromIntegral mem_f_init / mem_t_init
        , pMemForth = fromIntegral mem_f_init / mem_t_init
        , pDsk = if excl_stor
                 then computePDsk spindles_f_init $ fromIntegral spindles_t_init
@@ -359,7 +364,6 @@ create name_init mem_t_init mem_n_init mem_f_init
        , offline = offline_init
        , isMaster = False
        , nTags = []
-       , xMem = 0
        , mDsk = T.defReservedDiskRatio
        , loDsk = mDskToloDsk T.defReservedDiskRatio dsk_t_init
        , hiCpu = mCpuTohiCpu (T.iPolicyVcpuRatio T.defIPolicy) cpu_t_init
@@ -429,10 +433,6 @@ setRecvMigrationTags t val = t { rmigTags = val }
 -- | Set the location tags
 setLocationTags :: Node -> Set.Set String -> Node
 setLocationTags t val = t { locationTags = val }
-
--- | Sets the unnaccounted memory.
-setXmem :: Node -> Int -> Node
-setXmem t val = t { xMem = val }
 
 -- | Sets the hypervisor attribute.
 setHypervisor :: Node -> Hypervisor -> Node
@@ -760,14 +760,16 @@ removePri t inst =
        then updateForthcomingFields t
        else let
                 new_plist = delete iname (pList t)
-                new_mem = incIf (Instance.usesMemory inst) (fMem t)
-                                (Instance.mem inst)
+
+                (new_i_mem, new_free_mem) = prospectiveMem t inst False
+                new_p_mem = fromIntegral new_free_mem / tMem t
+                new_failn1 = new_free_mem <= rMem t
+
                 new_dsk = incIf uses_disk (fDsk t) (Instance.dsk inst)
                 new_free_sp = calcNewFreeSpindles False t inst
                 new_inst_sp = calcSpindleUse False t inst
-                new_mp = fromIntegral new_mem / tMem t
                 new_dp = computeNewPDsk t new_free_sp new_dsk
-                new_failn1 = new_mem <= rMem t
+
                 new_ucpu = decIf i_online (uCpu t) (Instance.vcpus inst)
                 new_rcpu = fromIntegral new_ucpu / tCpu t
                 new_load = utilLoad t `T.subUtil` Instance.util inst
@@ -776,8 +778,8 @@ removePri t inst =
                                  $ getLocationExclusionPairs t inst
 
             in updateForthcomingFields $
-                 t { pList = new_plist, fMem = new_mem, fDsk = new_dsk
-                   , failN1 = new_failn1, pMem = new_mp, pDsk = new_dp
+                 t { pList = new_plist, iMem = new_i_mem, fDsk = new_dsk
+                   , failN1 = new_failn1, pMem = new_p_mem, pDsk = new_dp
                    , uCpu = new_ucpu, pCpu = new_rcpu, utilLoad = new_load
                    , instSpindles = new_inst_sp, fSpindles = new_free_sp
                    , locationScore = locationScore t
@@ -836,7 +838,7 @@ removeSec t inst =
                              then old_rmem
                              else computeMaxRes new_peers
                 new_prem = fromIntegral new_rmem / tMem t
-                new_failn1 = fMem t <= new_rmem
+                new_failn1 = guaranteedFreeMem t <= new_rmem
                 new_dp = computeNewPDsk t new_free_sp new_dsk
                 old_load = utilLoad t
                 new_load = old_load
@@ -922,24 +924,23 @@ addPriEx force t inst =
              _ -> Ok $ updateForthcomingFields t
 
       else let
-               new_mem = decIf (Instance.usesMemory inst) (fMem t)
-                               (Instance.mem inst)
+               (new_i_mem, new_free_mem) = prospectiveMem t inst True
+               new_p_mem = fromIntegral new_free_mem / tMem t
+               new_failn1 = new_free_mem <= rMem t
+
                new_dsk = decIf uses_disk (fDsk t) (Instance.dsk inst)
                new_free_sp = calcNewFreeSpindles True t inst
                new_inst_sp = calcSpindleUse True t inst
-               new_failn1 = new_mem <= rMem t
                new_ucpu = incIf i_online (uCpu t) (Instance.vcpus inst)
                new_pcpu = fromIntegral new_ucpu / tCpu t
                new_dp = computeNewPDsk t new_free_sp new_dsk
                new_load = utilLoad t `T.addUtil` Instance.util inst
 
                new_plist = iname:pList t
-               new_mp = fromIntegral new_mem / tMem t
-
                new_instance_map = addTags (instanceMap t)
                                 $ getLocationExclusionPairs t inst
       in case () of
-        _ | new_mem <= 0 -> Bad T.FailMem
+        _ | new_free_mem <= 0 -> Bad T.FailMem
           | uses_disk && new_dsk <= 0 -> Bad T.FailDisk
           | strict && uses_disk && new_dsk < loDsk t -> Bad T.FailDisk
           | uses_disk && exclStorage t && new_free_sp < 0 -> Bad T.FailSpindles
@@ -954,10 +955,10 @@ addPriEx force t inst =
           | otherwise ->
               Ok . updateForthcomingFields $
                 t { pList = new_plist
-                  , fMem = new_mem
+                  , iMem = new_i_mem
                   , fDsk = new_dsk
                   , failN1 = new_failn1
-                  , pMem = new_mp
+                  , pMem = new_p_mem
                   , pDsk = new_dp
                   , uCpu = new_ucpu
                   , pCpu = new_pcpu
@@ -1035,7 +1036,7 @@ addSecExEx ignore_disks force t inst pdx =
 
              _ -> Ok $ updateForthcomingFields t
       else let
-               old_mem = fMem t
+               old_mem = guaranteedFreeMem t
                new_dsk = fDsk t - Instance.dsk inst
                new_free_sp = calcNewFreeSpindles True t inst
                new_inst_sp = calcSpindleUse True t inst
@@ -1094,14 +1095,86 @@ availDisk t =
 iDsk :: Node -> Int
 iDsk t = truncate (tDsk t) - fDsk t
 
+-- | Returns state-of-world free memory on the node.
+-- | NOTE: This value is valid only before placement simulations.
+-- | TODO: Redefine this for memoy overcommitment.
+reportedFreeMem :: Node -> Int
+reportedFreeMem = fMem
+
+-- | Computes state-of-record free memory on the node.
+-- | TODO: Redefine this for memory overcommitment.
+recordedFreeMem :: Node -> Int
+recordedFreeMem t =
+  let total = tMem t
+      node = nMem t
+      inst = iMem t
+  in truncate total - node - inst
+
+-- | Computes the amount of missing memory on the node.
+-- NOTE: This formula uses free memory for calculations as opposed to
+-- used_memory in the definition, that's why it is the inverse.
+-- Explanations for missing memory (+) positive, (-) negative:
+-- (+) instances are using more memory that state-of-record
+--     - on KVM this might be due to the overhead per qemu process
+--     - on Xen manually upsized domains (xen mem-set)
+-- (+) on KVM non-qemu processes might be using more memory than what is
+--     reserved for node (no isolation)
+-- (-) on KVM qemu processes allocate memory on demand, thus an instance grows
+--     over its lifetime until it reaches state-of-record (+overhead)
+-- (-) on KVM KSM might be active
+-- (-) on Xen manually downsized domains (xen mem-set)
+missingMem :: Node -> Int
+missingMem t =
+  let state_of_world = reportedFreeMem t
+      state_of_record = recordedFreeMem t
+  in state_of_record - state_of_world
+
+-- | Computes the 'guaranteed' free memory, that is the minimum of what
+-- is reported by the node (available bytes) and our calculation based on
+-- instance sizes (our records), thus considering missing memory.
+-- NOTE 1: During placement simulations, the recorded memory changes, as
+-- instances are added/removed from the node, thus we have to calculate the
+-- missingMem (correction) before altering state-of-record and then
+-- use that correction to estimate state-of-world memory usage _after_
+-- the placements are done rather than doing min(record, world).
+-- NOTE 2: This is still only an approximation on KVM. As we shuffle instances
+-- during the simulation we are considering their state-of-record size, but
+-- in the real world the moves would shuffle parts of missing memory as well.
+-- Unfortunately as long as we don't have a more finegrained model that can
+-- better explain missing memory (split down based on root causes), we can't
+-- do better.
+-- NOTE 3: This is a hard limit based on available bytes and our bookkeeping.
+-- In case of memory overcommitment, both recordedFreeMem and reportedFreeMem
+-- would be extended by swap size on KVM or baloon size on Xen (their nominal
+-- and reported values).
+guaranteedFreeMem :: Node -> Int
+guaranteedFreeMem t =
+ let state_of_record = recordedFreeMem t
+ in state_of_record - max 0 (missingMem t)
+
 -- | Computes the amount of available memory on a given node.
+-- Compared to guaranteedFreeMem, this takes into account also memory reserved for
+-- secondary instances.
+-- NOTE: In case of memory overcommitment, there would be also an additional
+-- soft limit based on RAM size dedicated for instances and sum of
+-- state-of-record instance sizes (iMem): (tMem - nMem)*overcommit_ratio - iMem
 availMem :: Node -> Int
 availMem t =
-  let _f = fMem t
-      _l = rMem t
-  in if _f < _l
-       then 0
-       else _f - _l
+  let reserved = rMem t
+      guaranteed = guaranteedFreeMem t
+  in max 0 (guaranteed - reserved)
+
+-- | Prospective memory stats after instance operation.
+prospectiveMem :: Node -> Instance
+               -> Bool       -- ^ Operation: True if add, False for remove.
+               -> (Int, Int) -- ^ Tuple (used_by_instances, guaranteed_free_mem)
+prospectiveMem node inst add =
+  let uses_mem = (Instance.usesMemory inst)
+      condOp = if add then incIf else decIf
+      new_i_mem = condOp uses_mem (iMem node) (Instance.mem inst)
+      new_node = node { iMem = new_i_mem }
+      new_free_mem = guaranteedFreeMem new_node
+ in (new_i_mem, new_free_mem)
 
 -- | Computes the amount of available memory on a given node.
 availCpu :: Node -> Int
@@ -1111,10 +1184,6 @@ availCpu t =
   in if _l >= _u
        then _l - _u
        else 0
-
--- | The memory used by instances on a given node.
-iMem :: Node -> Int
-iMem t = truncate (tMem t) - nMem t - xMem t - fMem t
 
 -- * Node graph functions
 -- These functions do the transformations needed so that nodes can be
@@ -1193,9 +1262,10 @@ showField t field =
     "nmem" -> printf "%5d" $ nMem t
     "xmem" -> printf "%5d" $ xMem t
     "fmem" -> printf "%5d" $ fMem t
+    "gmem" -> printf "%5d" $ guaranteedFreeMem t
     "imem" -> printf "%5d" $ iMem t
     "rmem" -> printf "%5d" $ rMem t
-    "amem" -> printf "%5d" $ fMem t - rMem t
+    "amem" -> printf "%5d" $ availMem t
     "tdsk" -> printf "%5.0f" $ tDsk t / 1024
     "fdsk" -> printf "%5d" $ fDsk t `div` 1024
     "tcpu" -> printf "%4.0f" $ tCpu t
@@ -1234,9 +1304,10 @@ showHeader field =
     "nmem" -> ("n_mem", True)
     "xmem" -> ("x_mem", True)
     "fmem" -> ("f_mem", True)
+    "gmem" -> ("g_mem", True)
+    "amem" -> ("a_mem", True)
     "imem" -> ("i_mem", True)
     "rmem" -> ("r_mem", True)
-    "amem" -> ("a_mem", True)
     "tdsk" -> ("t_dsk", True)
     "fdsk" -> ("f_dsk", True)
     "tcpu" -> ("pcpu", True)
@@ -1323,7 +1394,7 @@ genAddTagsOpCode node tags = OpCodes.OpTagsSet
 -- | Constant holding the fields we're displaying by default.
 defaultFields :: [String]
 defaultFields =
-  [ "status", "name", "tmem", "nmem", "imem", "xmem", "fmem"
+  [ "status", "name", "tmem", "nmem", "imem", "xmem", "fmem", "gmem", "amem"
   , "rmem", "tdsk", "fdsk", "tcpu", "ucpu", "pcnt", "scnt"
   , "pfmem", "pfdsk", "rcpu"
   , "cload", "mload", "dload", "nload" ]

--- a/src/Ganeti/HTools/Program/Hail.hs
+++ b/src/Ganeti/HTools/Program/Hail.hs
@@ -70,6 +70,7 @@ options =
     , oRestrictToNodes
     , oMonD
     , oMonDXen
+    , oStaticKvmNodeMemory
     ]
 
 -- | The list of arguments supported by the program.

--- a/src/Ganeti/HTools/Program/Hbal.hs
+++ b/src/Ganeti/HTools/Program/Hbal.hs
@@ -95,6 +95,7 @@ options = do
     , oVerbose
     , oQuiet
     , oOfflineNode
+    , oStaticKvmNodeMemory
     , oMinScore
     , oMaxCpu
     , oMinDisk

--- a/src/Ganeti/HTools/Program/Hinfo.hs
+++ b/src/Ganeti/HTools/Program/Hinfo.hs
@@ -75,6 +75,7 @@ options = do
     , oIgnoreDyn
     , oMonD
     , oMonDDataFile
+    , oStaticKvmNodeMemory
     ]
 
 -- | The list of arguments supported by the program.

--- a/src/Ganeti/HTools/Program/Hroller.hs
+++ b/src/Ganeti/HTools/Program/Hroller.hs
@@ -85,6 +85,7 @@ options = do
     , oIgnoreNonRedundant
     , oForce
     , oOneStepOnly
+    , oStaticKvmNodeMemory
     ]
 
 -- | The list of arguments supported by the program.

--- a/src/Ganeti/HTools/Program/Hspace.hs
+++ b/src/Ganeti/HTools/Program/Hspace.hs
@@ -93,6 +93,7 @@ options = do
     , oStdSpec
     , oTieredSpec
     , oSaveCluster
+    , oStaticKvmNodeMemory
     ]
 
 -- | The list of arguments supported by the program.

--- a/src/Ganeti/HTools/Program/Hsqueeze.hs
+++ b/src/Ganeti/HTools/Program/Hsqueeze.hs
@@ -84,6 +84,7 @@ options = do
     , oPrintCommands
     , oVerbose
     , oNoHeaders
+    , oStaticKvmNodeMemory
     ]
 
 -- | The list of arguments supported by the program.

--- a/test/hs/Test/Ganeti/HTools/Backend/Text.hs
+++ b/test/hs/Test/Ganeti/HTools/Backend/Text.hs
@@ -213,8 +213,11 @@ prop_NodeLSIdempotent :: Property
 prop_NodeLSIdempotent =
   forAll (genNode (Just 1) Nothing) $ \node ->
   -- override failN1 to what loadNode returns by default
+  -- override pMem as that is updated after loading in Loader.updateMemStat
   let n = Node.setPolicy Types.defIPolicy $
-          node { Node.failN1 = True, Node.offline = False }
+          node { Node.failN1 = True,
+                 Node.offline = False,
+                 Node.pMem = 0}
   in
     (Text.loadNode defGroupAssoc.
          Utils.sepSplit '|' . Text.serializeNode defGroupList) n ==?
@@ -276,7 +279,12 @@ prop_CreateSerialise =
        Ok (_, _, _, [], _) -> counterexample
                               "Failed to allocate: no allocations" False
        Ok (_, nl', il, _, _) ->
-         let cdata = Loader.ClusterData defGroupList nl' il ctags
+         let
+             -- makeSmallCluster created an empty cluster, that had some instances allocated,
+             -- so we need to simulate that the hyperwisor now reports less fMem, otherwise
+             -- Loader.checkData will detect missing memory after deserialization.
+             nl1 = Container.map (\n -> n { Node.fMem = Node.recordedFreeMem n }) nl'
+             cdata = Loader.ClusterData defGroupList nl1 il ctags
                      Types.defIPolicy
              saved = Text.serializeCluster cdata
          in case Text.parseData saved >>= Loader.mergeData [] [] [] [] (TOD 0 0)
@@ -288,7 +296,7 @@ prop_CreateSerialise =
                            , cpol2 ==? Types.defIPolicy
                            , il2 ==? il
                            , gl2 ==? defGroupList
-                           , nl3 ==? nl'
+                           , nl3 ==? nl1
                            ]
 
 testSuite "HTools/Backend/Text"

--- a/test/hs/Test/Ganeti/HTools/Node.hs
+++ b/test/hs/Test/Ganeti/HTools/Node.hs
@@ -106,8 +106,9 @@ genNode min_multiplier max_multiplier = do
   let n = Node.create name (fromIntegral mem_t) mem_n mem_f
           (fromIntegral dsk_t) dsk_f (fromIntegral cpu_t) cpu_n offl spindles
           0 0 False
-      n' = Node.setPolicy nullIPolicy n
-  return $ Node.buildPeers n' Container.empty
+      n1 = Node.setPolicy nullIPolicy n
+      n2 = Loader.updateMemStat n1 Container.empty
+  return $ Node.buildPeers n2 Container.empty
 
 -- | Helper function to generate a sane node.
 genOnlineNode :: Gen Node.Node
@@ -203,11 +204,6 @@ prop_setOffline :: Node.Node -> Bool -> Property
 prop_setOffline node status =
   Node.offline newnode ==? status
     where newnode = Node.setOffline node status
-
-prop_setXmem :: Node.Node -> Int -> Property
-prop_setXmem node xm =
-  Node.xMem newnode ==? xm
-    where newnode = Node.setXmem node xm
 
 prop_setMcpu :: Node.Node -> Double -> Property
 prop_setMcpu node mc =
@@ -469,7 +465,6 @@ testSuite "HTools/Node"
             [ 'prop_setAlias
             , 'prop_setOffline
             , 'prop_setMcpu
-            , 'prop_setXmem
             , 'prop_addPriFM
             , 'prop_addPriFD
             , 'prop_addPriFS


### PR DESCRIPTION
Hi, 

Please review my latest take on fixing ganeti memory model. I've tried to implement the memory model as discussed in [1] and proposed in [2], but without introducing memory overcommitment (swap etc) or dependencies on 2.17 features. The changes should fix missing memory, node memory as reported by hbal & friends resulting in a more conservative estimation of available memory on the node. This should prevent situations, when the KVM node is involuntarily oversubscribed - as instances touch more memory, they grow and at some point this leads to OOM kills. This implementation of the proposed memory model can be easily extended to support memory overcommitment (as in [2]) by adding additional state variables (total/available swap size) and a additional constraint based on overcommitment ratio, some hints are left in code comments.

[1] https://code.google.com/p/ganeti/issues/detail?id=127 
[2] https://groups.google.com/forum/#!searchin/ganeti-devel/memory$20model%7Csort:relevance/ganeti-devel/lDfiAvBeqPw/JBXyAUfuAwAJ


